### PR TITLE
Fix up build process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+module.wren
+

--- a/scripts/bundle.py
+++ b/scripts/bundle.py
@@ -21,7 +21,7 @@ sources = [os.path.join(dirpath, path)
     for path in fnmatch.filter(files, '*.wren')]
 
 # Workaround for https://github.com/munificent/wren/issues/246.
-a = sources.index('/Users/gavin/Projects/wren-test/src/matchers.wren')
+a = sources.index(sourcesDirectory + '/matchers.wren')
 b = len(sources) - 1
 sources[b], sources[a] = sources[a], sources[b]
 


### PR DESCRIPTION
allowing non-gavins to generate the `module.wren` :smile: 

and making sure `module.wren` doesn't get committed, since it doesn't seem to currently be
