### PR TITLE
implement toDeepEqual to compare complex objects

### DIFF
--- a/src/matchers/base.wren
+++ b/src/matchers/base.wren
@@ -79,11 +79,70 @@ class BaseMatchers {
     report_(_value == other, message)
   }
 
+  /**
+   * Asserts that the value is deeply equal to the given value.
+   *
+   * @param {*} other Object that this value should be deeply equal to.
+   */
+  toDeepEqual (other) {
+    var message = "Expected " + _value.toString + " to deeply equal " +  other.toString
+    report_(isDeeplyEqual_(_value, other), message)
+  }
+
   report_ (result, message) {
     result = _negated ? !result : result
 
     var expectation = Expectation.new(result, message)
     Fiber.yield(expectation)
+  }
+
+  isDeeplyEqual_ (a, b) {
+    if (a == b) {
+      return true
+    }
+    if (a.type != b.type) {
+      return false
+    }
+
+    if (a is List) {
+      return sequenceIsEqual_(a, b)
+    }
+
+    if (a is Map) {
+      return mapIsEqual_(a, b)
+    }
+
+    return false
+  }
+
+  sequenceIsEqual_ (a, b) {
+    if (a.count != b.count) {
+      return false
+    }
+
+    var i = 0
+    while (i < a.count) {
+      if (!isDeeplyEqual_(a[i], b[i])) {
+        return false
+      }
+      i = i + 1
+    }
+
+    return true
+  }
+
+  mapIsEqual_ (a, b) {
+    if (a.keys.count != b.keys.count) {
+      return false
+    }
+
+    for (key in a.keys) {
+      if (!isDeeplyEqual_(a[key], b[key])) {
+        return false
+      }
+    }
+
+    return true
   }
 
   /**

--- a/test/src/matchers/test-base.wren
+++ b/test/src/matchers/test-base.wren
@@ -216,4 +216,20 @@ var TestBaseMatchers = Suite.new("BaseMatchers") { |it|
           "Expected string to equal value")
     }
   }
+
+  it.suite("#toDeepEqual") { |it|
+    it.should("pass for deeply equal objects") {
+      var a = {"a": 1, "b": false, "c": [1, 2, 3], "d": {"e": [4, 5, 6]}}
+      var b = {"a": 1, "b": false, "c": [1, 2, 3], "d": {"e": [4, 5, 6]}}
+
+      Expect.call(a).toDeepEqual(b)
+    }
+
+    it.should("fail for unequal objects") {
+      var a = {"a": 1, "b": false, "c": [1, 2, 3], "d": {"e": [4, 5, 6]}}
+      var b = {"a": 1, "b": false, "c": [1, 2, 3], "d": {"e": [4, 5000, 6]}}
+
+      Expect.call(a).not.toDeepEqual(b)
+    }
+  }
 }


### PR DESCRIPTION
This could be naive and probably needs way more testing, but I saw #7 and figured I'd give it a shot.

I thought it was a good idea to separate `toDeepEqual` from `toEqual`, so you can still simply compare `Map` references, for example.

Let me know what you think :star2: 
